### PR TITLE
Pin Python to 3.6 in conda install cmd

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ MAINTAINER Jon Krohn <jon@untapt.com>
 USER $NB_USER
 
 # install TensorFlow
-RUN conda install --quiet --yes 'tensorflow=1.0*'
+RUN conda install --quiet --yes python=3.6 'tensorflow=1.0*'
 
 # install tflearn and keras: 
 RUN pip install tflearn==0.3.2


### PR DESCRIPTION
For some reason, doing a `conda install` of `tensorflow=1.0*` appears to
make conda want to downgrade from Python 3.6 to 2.7 and this causes
problems like:

```
$ sudo docker run -v $(pwd):/home/jovyan/work -it --rm -p 8888:8888 tensorflow-ll-stack
/usr/local/bin/start-notebook.sh: ignoring /usr/local/bin/start-notebook.d/*

Container must be run with group "root" to update passwd file
Executing the command: jupyter notebook
Traceback (most recent call last):
  File "/opt/conda/bin/jupyter-notebook", line 4, in <module>
    import notebook.notebookapp
ImportError: No module named notebook.notebookapp
```

Fixes: GH-31